### PR TITLE
Deferred bone changes

### DIFF
--- a/lua/entities/ent_advbonemerge.lua
+++ b/lua/entities/ent_advbonemerge.lua
@@ -1419,6 +1419,10 @@ end, "Data")
 
 local meta = FindMetaTable("Entity")
 
+//We allow 10 frames as the client based on the 10 frames until buildbonepositions falls asleep. 
+//This can be tuned to observe various effects
+local BONE_CHANGE_FRAMES = 10
+
 //When an entity is bonemanipped, wake up the BuildBonePositions function of itself and/or any ents advbonemerged to it
 AdvBone_ResetBoneChangeTimeOnChildren = function(ent, networking) //global func so animprop code can use it
 	if CLIENT then
@@ -1443,6 +1447,13 @@ AdvBone_ResetBoneChangeTimeOnChildren = function(ent, networking) //global func 
 			net.Start("AdvBone_ResetBoneChangeTimeOnChildren_SendToCl", true)
 				net.WriteEntity(ent)
 			net.Broadcast()
+			timer.Simple(BONE_CHANGE_FRAMES * FrameTime(), function()
+				//We don't want the client to always control when the bones will be asleep.
+				//Fallback to using the server to set this in case. As a note, the client's
+				//framerate is always faster than the server, so this timer will always set
+				//the booleans late, unless the client hangs up and doesn't send it in time.
+				ent.AdvBone_BonesAsleep = true
+			end)
 		end
 	end
 end
@@ -1453,26 +1464,33 @@ if SERVER then
 
 	net.Receive("AdvBone_UpdateBoneAsleep_SendToSv", function()
 		local ent = net.ReadEntity()
-		local bool = net.ReadBool()
-		ent.AdvBone_BonesAsleep = bool
+		ent.AdvBone_BonesAsleep = true
 	end)
 else
-	local function sendBoneAsleep(ent, bool)
+	local function sendBoneAsleep(ent)
 		net.Start("AdvBone_UpdateBoneAsleep_SendToSv", true)
 			net.WriteEntity(ent)
-			net.WriteBool(bool)
 		net.SendToServer()
 	end
-
-	//We allow 10 frames as the client based on the 10 frames until buildbonepositions falls asleep. This can be tuned to observe various effects
-	local BONE_CHANGE_DELAY = 10
 
 	net.Receive("AdvBone_ResetBoneChangeTimeOnChildren_SendToCl", function()
 		local ent = net.ReadEntity()
 		if IsValid(ent) then
 			AdvBone_ResetBoneChangeTimeOnChildren(ent)
-			timer.Simple(BONE_CHANGE_DELAY * FrameTime(), function()
-				sendBoneAsleep(ent, true)
+			local count = 0
+			local timerName = "AdvBone_SendBoneAsleepTimer_" .. tostring(ent:EntIndex())
+			timer.Create(timerName, FrameTime(), -1, function()
+				count = count + 1
+				if count >= BONE_CHANGE_FRAMES then
+					timer.Remove(timerName)
+					sendBoneAsleep(ent)
+				else
+					//To ensure that our timer runs with the client's framerate, we need to 
+					//adjust the timer  to the last frame render time. This isn't accurate as 
+					//it doesn't time the true frame render delay for the next frame, but it 
+					//is controlled by our framerate nonetheless.
+					timer.Adjust(timerName, FrameTime())
+				end
 			end)
 		end
 	end)

--- a/lua/entities/ent_advbonemerge.lua
+++ b/lua/entities/ent_advbonemerge.lua
@@ -1434,7 +1434,7 @@ AdvBone_ResetBoneChangeTimeOnChildren = function(ent, networking) //global func 
 		//tickrate at all, so i don't know how we'd add any more of a delay without potentially breaking things for players with an insanely high framerate.
 		local time = CurTime()
 		ent.AdvBone_ResetBoneChangeTimeOnChildren_LastSent = ent.AdvBone_ResetBoneChangeTimeOnChildren_LastSent or time
-		if time > ent.AdvBone_ResetBoneChangeTimeOnChildren_LastSent then
+		if time - ent.AdvBone_ResetBoneChangeTimeOnChildren_LastSent > 0.1 then
 			ent.AdvBone_ResetBoneChangeTimeOnChildren_LastSent = time
 			net.Start("AdvBone_ResetBoneChangeTimeOnChildren_SendToCl", true)
 				net.WriteEntity(ent)

--- a/lua/weapons/gmod_tool/stools/advbonemerge.lua
+++ b/lua/weapons/gmod_tool/stools/advbonemerge.lua
@@ -671,7 +671,7 @@ if SERVER then
 		//or stop motion helper, but let's be safe here
 		local time = CurTime()
 		ent.AdvBone_ResetBoneChangeTime_LastSent = ent.AdvBone_ResetBoneChangeTime_LastSent or 0
-		if time > ent.AdvBone_ResetBoneChangeTime_LastSent then
+		if time - ent.AdvBone_ResetBoneChangeTime_LastSent > 0.1 then
 			ent.AdvBone_ResetBoneChangeTime_LastSent = time
 			net.Start("AdvBone_ResetBoneChangeTime_SendToCl", true)
 				net.WriteEntity(ent)


### PR DESCRIPTION
Noticed the new TODO based on extending the client delay after 10 frames instead of a frame. This PR implements a scheme where the server only sends up dates if the entity's AdvBone_BonesAsleep boolean is true. This gets set through a new network string, "AdvBone_UpdateBonesAsleep_SendToSv", which simply updates that boolean after a certain number of frames have passed on the client (by default, 10 frames). It's a simple debounce in the end.

If 10 frames is insufficient, the number of frames to check when to update bones can be easily tuned via the BONE_CHANGE_FRAMES constant. If this helps, the more frames, the lower the net rate to the client, which makes sense since bone changes updates are now "spread out."

ASIDE: I've also wondered how much this would impact players too, when I was making a [similar method to defer bone updates](https://github.com/vlazed/AdvBonemerge/blob/79c91035c1c0cc7ac27cc66e5699c5842b4009ef/lua/entities/ent_advbonemerge.lua#L1429). I think it would be good to test this extensively in multiplayer just to be sure if this is breaking